### PR TITLE
docs: add qwik-router to the libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@
 - [Qwik Heroicons](https://github.com/elilabes/heroicons-qwik): A Qwik implementation of Heroicons.
 - [Qwik Feather Icons](https://github.com/yeyon/qwik-feather-icons): Feather icons for Qwik, the Resumable Framework.
 - [Qwik Styled Vanilla-Extract](https://github.com/wmertens/qwik-styled-ve): 0-runtime CSS, Styled-Components-like (SC) API in Qwik, using vanilla-extract (VE) and stylis
+- [Qwik Router](https://github.com/dannyfranca/qwik-router) - Qwik Dynamic SPA-like router for Qwik, inspired by `vue-router` and `react-router`.
 
 ## Qwik Sites/Projects
 - [Qwik Home Page](https://qwik.builder.io/)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

I've recently published a component called qwik-router after the previous developer removed it from npm.

The component I published has been used in production, and I've seen value in sharing it with the world.

I'll keep maintaining it unless the Qwik team creates a dynamic router like the Vue team decided to do.

# Use cases and why

Many Qwik native solutions, like routing, are very attached to Qwik City, which is great for most use cases. But sometimes, more than a file-based routing is needed.

## Possible use cases are:

- Micro-frontends with Qwik, where you need to load different apps on the same page
- When you need a component-based routing with customized rules.
- When you need multiple routers on the same page.

# Checklist:

- [x] My code follows the [developer guidelines of this project](../CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
